### PR TITLE
added middleware for dynamically-generated pages

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,6 +18,8 @@ app.use(express.json());
 
 // Static directory
 app.use(express.static("public"));
+app.use('/static', express.static('public'))
+
 
 app.engine(
     "handlebars",


### PR DESCRIPTION
I added one line of code to the server, this looks like it allows a dynamically generated page (like our athletes' individual pages) to show:

// Static directory
app.use(express.static("public"));
app.use('/static', express.static('public'))

This didn't break anything on the local host so if it's OK with the two of you let's push it to heroku and see what happens.  We might have to try just replacing the first line there and only using the second.  Then if neither of those work we can just go back to the first.

The explanation from the express.js documentation says this:

To create a virtual path prefix (where the path does not actually exist in the file system) for files that are served by the express.static function, specify a mount path for the static directory, as shown below:

app.use('/static', express.static('public'))
Now, you can load the files that are in the public directory from the /static path prefix.